### PR TITLE
サンドボックスにファイルアクセスの権限を付与、また最小サポートバージョンの引き下げを設定

### DIFF
--- a/PrivateTalkApp.xcodeproj/project.pbxproj
+++ b/PrivateTalkApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		22D1BDFD2C667D5B006AD6D8 /* TalkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D1BDFC2C667D5B006AD6D8 /* TalkView.swift */; };
 		22D1BE012C667D80006AD6D8 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D1BE002C667D80006AD6D8 /* SettingView.swift */; };
 		22D1BE042C667DFF006AD6D8 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 22D1BE032C667DFF006AD6D8 /* Colors.xcassets */; };
+		22E19FEE2C6F44D600C4051F /* Entitlements.plist in Resources */ = {isa = PBXBuildFile; fileRef = 22E19FED2C6F44D600C4051F /* Entitlements.plist */; };
 		8EF16EB3B4B8B382C18D95F4 /* Pods_PrivateTalkApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AFCA3F4449B6E8A53D87804 /* Pods_PrivateTalkApp.framework */; };
 /* End PBXBuildFile section */
 
@@ -34,6 +35,7 @@
 		22D1BDFC2C667D5B006AD6D8 /* TalkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkView.swift; sourceTree = "<group>"; };
 		22D1BE002C667D80006AD6D8 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		22D1BE032C667DFF006AD6D8 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		22E19FED2C6F44D600C4051F /* Entitlements.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Entitlements.plist; sourceTree = "<group>"; };
 		68DA4C6266FB7A8600959865 /* Pods-PrivateTalkApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrivateTalkApp.debug.xcconfig"; path = "Target Support Files/Pods-PrivateTalkApp/Pods-PrivateTalkApp.debug.xcconfig"; sourceTree = "<group>"; };
 		760FEC05D04C75F691B1D513 /* Pods-PrivateTalkApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrivateTalkApp.release.xcconfig"; path = "Target Support Files/Pods-PrivateTalkApp/Pods-PrivateTalkApp.release.xcconfig"; sourceTree = "<group>"; };
 		9AFCA3F4449B6E8A53D87804 /* Pods_PrivateTalkApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrivateTalkApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,6 +85,7 @@
 				94783472EB47F1D3F80B0830 /* Pods */,
 				B5B052C34F685F0D0E5B3924 /* Frameworks */,
 				2239097E2C6E3BBC00B4DCFE /* License */,
+				22E19FEC2C6F449700C4051F /* Supporting Files */,
 			);
 			sourceTree = "<group>";
 		};
@@ -191,6 +194,14 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		22E19FEC2C6F449700C4051F /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				22E19FED2C6F44D600C4051F /* Entitlements.plist */,
+			);
+			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		94783472EB47F1D3F80B0830 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -271,6 +282,7 @@
 				223909802C6E3BF600B4DCFE /* LICENSE.txt in Resources */,
 				22D1BE042C667DFF006AD6D8 /* Colors.xcassets in Resources */,
 				22D1BDEC2C667A36006AD6D8 /* Preview Assets.xcassets in Resources */,
+				22E19FEE2C6F44D600C4051F /* Entitlements.plist in Resources */,
 				22D1BDE92C667A36006AD6D8 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -389,7 +401,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -446,7 +458,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -462,6 +474,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/Supporting Files/Entitlements.plist";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PrivateTalkApp/Preview Content\"";
@@ -474,7 +487,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -494,6 +507,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/Supporting Files/Entitlements.plist";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PrivateTalkApp/Preview Content\"";
@@ -506,7 +520,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Supporting Files/Entitlements.plist
+++ b/Supporting Files/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
# OverView
【**目的**】
- アプリからFSCalendarにアクセスできるようにする
- 最小サポートバージョンを引き下げる

【**実装内容**】
- Entitlements.plistを作成し、ファイルにアクセスできるよう権限を追加
- iOS Deployment Targetを16.0に変更