### PR TITLE
カレンダー（FSCalendar）のViewを実装

### DIFF
--- a/PrivateTalkApp.xcodeproj/project.pbxproj
+++ b/PrivateTalkApp.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2224E1B72C75DC2B0099C855 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2224E1B62C75DC2B0099C855 /* StringExtension.swift */; };
 		222BDF962C6DE92200638D4A /* NewsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BDF952C6DE92100638D4A /* NewsView.swift */; };
 		223909802C6E3BF600B4DCFE /* LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2239097F2C6E3BF600B4DCFE /* LICENSE.txt */; };
+		226D18ED2C7351D80066495A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 226D18EB2C7351D80066495A /* Localizable.strings */; };
 		22D1BDE52C667A34006AD6D8 /* PrivateTalkAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D1BDE42C667A34006AD6D8 /* PrivateTalkAppApp.swift */; };
 		22D1BDE72C667A34006AD6D8 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D1BDE62C667A34006AD6D8 /* TabBarView.swift */; };
 		22D1BDE92C667A36006AD6D8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 22D1BDE82C667A36006AD6D8 /* Assets.xcassets */; };
@@ -19,12 +21,16 @@
 		22D1BE012C667D80006AD6D8 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D1BE002C667D80006AD6D8 /* SettingView.swift */; };
 		22D1BE042C667DFF006AD6D8 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 22D1BE032C667DFF006AD6D8 /* Colors.xcassets */; };
 		22E19FEE2C6F44D600C4051F /* Entitlements.plist in Resources */ = {isa = PBXBuildFile; fileRef = 22E19FED2C6F44D600C4051F /* Entitlements.plist */; };
+		22E19FF02C6F517700C4051F /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E19FEF2C6F517700C4051F /* CalendarView.swift */; };
 		8EF16EB3B4B8B382C18D95F4 /* Pods_PrivateTalkApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AFCA3F4449B6E8A53D87804 /* Pods_PrivateTalkApp.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2224E1B62C75DC2B0099C855 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		222BDF952C6DE92100638D4A /* NewsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsView.swift; sourceTree = "<group>"; };
 		2239097F2C6E3BF600B4DCFE /* LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
+		226D18EC2C7351D80066495A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		226D18EE2C7351DE0066495A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		22D1BDE12C667A34006AD6D8 /* PrivateTalkApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PrivateTalkApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		22D1BDE42C667A34006AD6D8 /* PrivateTalkAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateTalkAppApp.swift; sourceTree = "<group>"; };
 		22D1BDE62C667A34006AD6D8 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
@@ -36,6 +42,7 @@
 		22D1BE002C667D80006AD6D8 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		22D1BE032C667DFF006AD6D8 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		22E19FED2C6F44D600C4051F /* Entitlements.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Entitlements.plist; sourceTree = "<group>"; };
+		22E19FEF2C6F517700C4051F /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
 		68DA4C6266FB7A8600959865 /* Pods-PrivateTalkApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrivateTalkApp.debug.xcconfig"; path = "Target Support Files/Pods-PrivateTalkApp/Pods-PrivateTalkApp.debug.xcconfig"; sourceTree = "<group>"; };
 		760FEC05D04C75F691B1D513 /* Pods-PrivateTalkApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrivateTalkApp.release.xcconfig"; path = "Target Support Files/Pods-PrivateTalkApp/Pods-PrivateTalkApp.release.xcconfig"; sourceTree = "<group>"; };
 		9AFCA3F4449B6E8A53D87804 /* Pods_PrivateTalkApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrivateTalkApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -53,6 +60,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2224E1B42C75DB580099C855 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				2224E1B52C75DB810099C855 /* Extensions */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		2224E1B52C75DB810099C855 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				2224E1B62C75DC2B0099C855 /* StringExtension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		222BDF932C6DE8FC00638D4A /* News */ = {
 			isa = PBXGroup;
 			children = (
@@ -108,6 +131,7 @@
 				22D1BDFE2C667D6B006AD6D8 /* Setting */,
 				22D1BE022C667D94006AD6D8 /* Resources */,
 				22D1BDEA2C667A36006AD6D8 /* Preview Content */,
+				2224E1B42C75DB580099C855 /* Utilities */,
 			);
 			path = PrivateTalkApp;
 			sourceTree = "<group>";
@@ -149,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				22D1BDF82C667D08006AD6D8 /* HomeView.swift */,
+				22E19FEF2C6F517700C4051F /* CalendarView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -190,6 +215,7 @@
 			children = (
 				22D1BDE82C667A36006AD6D8 /* Assets.xcassets */,
 				22D1BE032C667DFF006AD6D8 /* Colors.xcassets */,
+				226D18EB2C7351D80066495A /* Localizable.strings */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -263,6 +289,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ja,
 			);
 			mainGroup = 22D1BDD82C667A34006AD6D8;
 			productRefGroup = 22D1BDE22C667A34006AD6D8 /* Products */;
@@ -280,6 +307,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				223909802C6E3BF600B4DCFE /* LICENSE.txt in Resources */,
+				226D18ED2C7351D80066495A /* Localizable.strings in Resources */,
 				22D1BE042C667DFF006AD6D8 /* Colors.xcassets in Resources */,
 				22D1BDEC2C667A36006AD6D8 /* Preview Assets.xcassets in Resources */,
 				22E19FEE2C6F44D600C4051F /* Entitlements.plist in Resources */,
@@ -297,6 +325,8 @@
 			);
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PrivateTalkApp/Pods-PrivateTalkApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			inputPaths = (
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
@@ -338,8 +368,10 @@
 			files = (
 				22D1BDF52C667BA3006AD6D8 /* Tab.swift in Sources */,
 				22D1BDF92C667D08006AD6D8 /* HomeView.swift in Sources */,
+				22E19FF02C6F517700C4051F /* CalendarView.swift in Sources */,
 				22D1BDE72C667A34006AD6D8 /* TabBarView.swift in Sources */,
 				222BDF962C6DE92200638D4A /* NewsView.swift in Sources */,
+				2224E1B72C75DC2B0099C855 /* StringExtension.swift in Sources */,
 				22D1BE012C667D80006AD6D8 /* SettingView.swift in Sources */,
 				22D1BDFD2C667D5B006AD6D8 /* TalkView.swift in Sources */,
 				22D1BDE52C667A34006AD6D8 /* PrivateTalkAppApp.swift in Sources */,
@@ -347,6 +379,18 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		226D18EB2C7351D80066495A /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				226D18EC2C7351D80066495A /* en */,
+				226D18EE2C7351DE0066495A /* ja */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		22D1BDED2C667A36006AD6D8 /* Debug */ = {

--- a/PrivateTalkApp/Home/View/CalendarView.swift
+++ b/PrivateTalkApp/Home/View/CalendarView.swift
@@ -1,0 +1,208 @@
+//
+//  CalendarView.swift
+//  PrivateTalkApp
+//
+//  Created by 都甲裕希 on 2024/08/16.
+//
+
+import SwiftUI
+import FSCalendar
+
+// MARK: - FSCalendarView
+struct CalendarView: UIViewRepresentable {
+    
+    private struct Constants {
+        static let DEFAULT_LANGUAGE = "ja-JP"
+        static let HEADER_DATE_FORMAT_KEY = "calendar_format"
+        static let HEADER_TITLE_FONT_SIZE = 20.0
+        static let PREVIOUS_AND_NEXT_MONTH_ALPHA = 0.0
+        static let WEEKDAY_FONT_SIZE = 20.0
+        static let TITLE_FONT_SIZE = 16.0
+        static let TODAY_AND_SELECTED_BORDER_RADIUS = 1.0
+    }
+    
+    func makeCoordinator() -> FSCalendarCoordinator {
+        return FSCalendarCoordinator(parent: self)
+    }
+    
+    func makeUIView(context: Context) -> some UIView {
+        // 設定されている優先言語を取得
+        let preferredLanguage = Locale.preferredLanguages.first ?? Constants.DEFAULT_LANGUAGE
+        // 設定されている言語に合わせてフォーマットを取得
+        let format = NSLocalizedString(Constants.HEADER_DATE_FORMAT_KEY, comment: String.empty)
+        // カレンダーの設定
+        let fsCalendar = FSCalendar()
+            .setLocale(identifier: preferredLanguage)
+            .setHeaderDateFormat(format: format)
+            .setHeaderTitleFont(size: Constants.HEADER_TITLE_FONT_SIZE)
+            .setHeaderTitleColor(color: .label)
+            .setHeaderMinimumDissolvedAlpha(alpha: Constants.PREVIOUS_AND_NEXT_MONTH_ALPHA)
+            .setWeekdayFont(size: Constants.WEEKDAY_FONT_SIZE)
+            .setCalendarWeekdayBackgroundColor(color: .calendarPrimary)
+            .setWeekdayTextColor(color: .iconBlack)
+            .setTitleFont(size: Constants.TITLE_FONT_SIZE, weight: .bold)
+            .setTodayColor(color: .calendarPrimary)
+            .setSelectionColor(color: .clear)
+            .setBorderSelectionColor(color: .calendarSelectedBackground)
+            .setTitleSelectionColor(color: .iconBlack)
+            .setTitleDefaultColor(color: .iconBlack)
+            .setTitleWeekendColor(color: .calendarPrimary)
+            .setBorderRadius(radius: Constants.TODAY_AND_SELECTED_BORDER_RADIUS)
+        
+        fsCalendar.delegate = context.coordinator
+        fsCalendar.dataSource = context.coordinator
+        
+        return fsCalendar
+    }
+    
+    func updateUIView(_ uiView: UIViewType, context: Context) {
+        
+    }
+}
+
+// MARK: - Coordinator
+class FSCalendarCoordinator: NSObject, FSCalendarDelegate, FSCalendarDataSource {
+    
+    var parent: CalendarView
+    
+    init(parent: CalendarView) {
+        self.parent = parent
+    }
+}
+
+// MARK: - extension
+extension FSCalendar {
+    
+    /// 言語設定
+    /// - parameter identifier: ロケールの識別子（日本語表示の場合は"ja-JP"）
+    @discardableResult
+    func setLocale(identifier: String) -> Self {
+        self.locale = Locale(identifier: identifier)
+        return self
+    }
+    
+    /// ヘッダー表示のフォーマットをセット
+    /// - parameter format: フォーマット
+    @discardableResult
+    func setHeaderDateFormat(format: String) -> Self {
+        self.appearance.headerDateFormat = format
+        return self
+    }
+    
+    /// ヘッダーテキストサイズをセット
+    /// - parameter size: テキストサイズ
+    @discardableResult
+    func setHeaderTitleFont(size: CGFloat) -> Self {
+        self.appearance.headerTitleFont = UIFont.systemFont(ofSize: size)
+        return self
+    }
+    
+    /// ヘッダーテキストカラーをセット
+    /// - parameter color: テキストカラー
+    @discardableResult
+    func setHeaderTitleColor(color: UIColor) -> Self {
+        self.appearance.headerTitleColor = color
+        return self
+    }
+    
+    /// 前月、翌月表示のアルファ量をセット
+    /// - parameter alpha: アルファ量（0で非表示）
+    @discardableResult
+    func setHeaderMinimumDissolvedAlpha(alpha: CGFloat) -> Self {
+        self.appearance.headerMinimumDissolvedAlpha = alpha
+        return self
+    }
+    
+    /// 曜日表示のテキストサイズをセット
+    /// - parameter size: テキストサイズ
+    @discardableResult
+    func setWeekdayFont(size: CGFloat) -> Self {
+        self.appearance.weekdayFont = UIFont.systemFont(ofSize: size)
+        return self
+    }
+    
+    /// 曜日表示の背景色をセット
+    /// - parameter color: 背景色
+    @discardableResult
+    func setCalendarWeekdayBackgroundColor(color: UIColor) -> Self {
+        self.calendarWeekdayView.backgroundColor = color
+        return self
+    }
+    
+    /// 曜日表示のテキストカラーをセット
+    /// - parameter color: テキストカラー
+    @discardableResult
+    func setWeekdayTextColor(color: UIColor) -> Self {
+        self.appearance.weekdayTextColor = color
+        return self
+    }
+    
+    /// 日付のテキスト、ウェイトサイズをセット
+    /// - parameter size: テキストサイズ
+    /// - parameter weight: ウェイトサイズ
+    @discardableResult
+    func setTitleFont(size: CGFloat, weight: UIFont.Weight) -> Self {
+        self.appearance.titleFont = UIFont.systemFont(ofSize: size, weight: weight)
+        return self
+    }
+    
+    /// 本日の背景色をセット
+    /// - parameter color: 背景色
+    @discardableResult
+    func setTodayColor(color: UIColor) -> Self {
+        self.appearance.todayColor = color
+        return self
+    }
+    
+    /// 選択した日付の背景色をセット
+    /// - parameter color: 背景色
+    @discardableResult
+    func setSelectionColor(color: UIColor) -> Self {
+        self.appearance.selectionColor = color
+        return self
+    }
+    
+    /// 選択した日付のボーダーカラーをセット
+    /// - parameter color: ボーダーカラー
+    @discardableResult
+    func setBorderSelectionColor(color: UIColor) -> Self {
+        self.appearance.borderSelectionColor = color
+        return self
+    }
+    
+    /// 選択した日付のテキストカラーをセット
+    /// - parameter color: テキストカラー
+    @discardableResult
+    func setTitleSelectionColor(color: UIColor) -> Self {
+        self.appearance.titleSelectionColor = color
+        return self
+    }
+    
+    /// 平日の日付のテキストカラーをセット
+    /// - parameter color: テキストカラー
+    @discardableResult
+    func setTitleDefaultColor(color: UIColor) -> Self {
+        self.appearance.titleDefaultColor = color
+        return self
+    }
+    
+    /// 週末（土、日曜の）日付のテキストカラーをセット
+    /// - parameter color: テキストカラー
+    @discardableResult
+    func setTitleWeekendColor(color: UIColor) -> Self {
+        self.appearance.titleWeekendColor = color
+        return self
+    }
+    
+    /// 本日・選択日の塗りつぶし角丸量
+    /// - parameter radius: 角丸量
+    @discardableResult
+    func setBorderRadius(radius: CGFloat) -> Self {
+        self.appearance.borderRadius = radius
+        return self
+    }
+}
+
+#Preview {
+    CalendarView()
+}

--- a/PrivateTalkApp/Home/View/HomeView.swift
+++ b/PrivateTalkApp/Home/View/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        CalendarView()
     }
 }
 

--- a/PrivateTalkApp/MainTab/View/Tab.swift
+++ b/PrivateTalkApp/MainTab/View/Tab.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+
+// MARK: - enum
 enum Tab: CaseIterable {
     case home
     case talk
@@ -15,45 +17,45 @@ enum Tab: CaseIterable {
 
 // MARK: - Constants
 private struct Constants {
-    static let homeViewImageName = "house.fill"
-    static let homeViewTabBerText = "ホーム"
-    static let talkViewImageName = "message.badge.filled.fill.rtl"
-    static let talkViewTabBerText = "トーク"
-    static let newsViewImageName = "newspaper.fill"
-    static let newsViewTabBerText = "ニュース"
-    static let settingViewImageName = "gearshape.fill"
-    static let settingViewTabBerText = "設定"
+    static let HOME_VIEW_IMAGE_NAME = "house.fill"
+    static let HOME_VIEW_TAB_BAR_TEXT = "ホーム"
+    static let TALK_VIEW_IMAGE_NAME = "message.badge.filled.fill.rtl"
+    static let TALK_VIEW_TAB_BAR_TEXT = "トーク"
+    static let NEWS_VIEW_IMAGE_NAME = "newspaper.fill"
+    static let NEWS_VIEW_TAB_BAR_TEXT = "ニュース"
+    static let SETTIMG_VIEW_IMAGE_NAME = "gearshape.fill"
+    static let sSETTIMG_VIEW_TAB_BAR_TEXT = "設定"
 }
 
 // MARK: - extension
 extension Tab {
     /// タブバーに表示するイメージ名を返すメソッド
-    /// Return: イメージ名
+    /// - returns: イメージ名
     func imageName() -> String {
         switch self {
         case .home:
-            return Constants.homeViewImageName
+            return Constants.HOME_VIEW_IMAGE_NAME
         case .talk:
-            return Constants.talkViewImageName
+            return Constants.TALK_VIEW_IMAGE_NAME
         case .news:
-            return Constants.newsViewImageName
+            return Constants.NEWS_VIEW_IMAGE_NAME
         case .setting:
-            return Constants.settingViewImageName
+            return Constants.SETTIMG_VIEW_IMAGE_NAME
         }
     }
     
     /// タブバーに表示するタブのテキストを返すメソッド
-    /// Return: タブ名
+    /// - returns: タブ名
     func tabText() -> String {
         switch self {
         case .home:
-            return Constants.homeViewTabBerText
+            return Constants.HOME_VIEW_TAB_BAR_TEXT
         case .talk:
-            return Constants.talkViewTabBerText
+            return Constants.TALK_VIEW_TAB_BAR_TEXT
         case .news:
-            return Constants.newsViewTabBerText
+            return Constants.NEWS_VIEW_TAB_BAR_TEXT
         case .setting:
-            return Constants.settingViewTabBerText
+            return Constants.sSETTIMG_VIEW_TAB_BAR_TEXT
         }
     }
 }

--- a/PrivateTalkApp/MainTab/View/TabBarView.swift
+++ b/PrivateTalkApp/MainTab/View/TabBarView.swift
@@ -7,6 +7,17 @@
 
 import SwiftUI
 
+// MARK: - Constants
+private struct Constants {
+    static let TAB_BAR_VIEW_SPACING = 0.0
+    static let ITEM_IN_TAB_SPACING = 5.0
+    static let IMAGE_IN_TAB_WIDTH = 25.0
+    static let IMAGE_IN_TAB_HEIGHT = 25.0
+    static let TAB_HEIGHT = 30.0
+    static let TAB_VERTICAL = 10.0
+}
+
+// MARK: - TabBarView
 struct TabBarView: View {
     
     init() {
@@ -17,7 +28,7 @@ struct TabBarView: View {
     @State var currentTab: Tab = .home
     
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: Constants.TAB_BAR_VIEW_SPACING) {
             TabView(selection: $currentTab) {
                 HomeView().tag(Tab.home)
                 TalkView().tag(Tab.talk)
@@ -30,24 +41,24 @@ struct TabBarView: View {
     }
 }
 
-/// カスタムタブバー
+// MARK: - CustomTabBar
 struct CustomTabBar: View {
     
     @Binding var currentTab: Tab
     
     var body: some View {
         GeometryReader { geometry in
-            HStack(spacing: 0) {
+            HStack(spacing: Constants.TAB_BAR_VIEW_SPACING) {
                 ForEach(Tab.allCases, id: \.hashValue) { tab in
                     Button {
                         // 選択されたタブをデフォルトのタブに設定する
                         currentTab = tab
                     } label: {
-                        VStack(spacing: 5) {
+                        VStack(spacing: Constants.ITEM_IN_TAB_SPACING) {
                             Image(systemName: tab.imageName())
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)
-                                .frame(width: 25, height: 25)
+                                .frame(width: Constants.IMAGE_IN_TAB_WIDTH, height: Constants.IMAGE_IN_TAB_HEIGHT)
                                 .foregroundColor(currentTab == tab ? .iconBlack : .gray)
                             Text(tab.tabText())
                                 .font(.caption)
@@ -60,8 +71,8 @@ struct CustomTabBar: View {
             }
             .frame(maxWidth: .infinity)
         }
-        .frame(height: 30.0)
-        .padding(.vertical, 10.0)
+        .frame(height: Constants.TAB_HEIGHT)
+        .padding(.vertical, Constants.TAB_VERTICAL)
     }
 }
 

--- a/PrivateTalkApp/Resources/Colors.xcassets/calendarPrimaryColor.colorset/Contents.json
+++ b/PrivateTalkApp/Resources/Colors.xcassets/calendarPrimaryColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.500",
+          "red" : "0.787"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PrivateTalkApp/Resources/Colors.xcassets/calendarSelectedBackgroundColor.colorset/Contents.json
+++ b/PrivateTalkApp/Resources/Colors.xcassets/calendarSelectedBackgroundColor.colorset/Contents.json
@@ -1,0 +1,33 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "tvos",
+        "reference" : "systemTealColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PrivateTalkApp/Resources/en.lproj/Localizable.strings
+++ b/PrivateTalkApp/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+/* 
+  Localizable.strings
+  PrivateTalkApp
+
+  Created by 都甲裕希 on 2024/08/19.
+  
+*/
+
+// FSCalendar
+"calendar_format" = "MMMM YYYY";

--- a/PrivateTalkApp/Resources/ja.lproj/Localizable.strings
+++ b/PrivateTalkApp/Resources/ja.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+/* 
+  Localizable.strings
+  PrivateTalkApp
+
+  Created by 都甲裕希 on 2024/08/19.
+  
+*/
+
+// FSCalendar
+"calendar_format" = "yyyy年M月";

--- a/PrivateTalkApp/Utilities/Extensions/StringExtension.swift
+++ b/PrivateTalkApp/Utilities/Extensions/StringExtension.swift
@@ -1,0 +1,22 @@
+//
+//  StringExtension.swift
+//  PrivateTalkApp
+//
+//  Created by 都甲裕希 on 2024/08/21.
+//
+
+import Foundation
+
+// MARK: - Constants
+private struct Constants {
+    static let EMPTY_STRING = ""
+}
+
+// MARK: - extension
+extension String {
+    
+    /// 空文字
+    static var empty: String {
+        return Constants.EMPTY_STRING
+    }
+}


### PR DESCRIPTION
# OverView
【**目的**】
- ホームにカレンダー機能を搭載する

【**実装内容**】
- FSCalendarを表示し、用意されているプロパティでUIを調整
- Constantsの定数名を大文字に変更
- StringのExtensionファイルを追加
- Localizable.stringsを追加