### PR TITLE
Tabのレイアウト修正

### DIFF
--- a/PrivateTalkApp/MainTab/View/TabBarView.swift
+++ b/PrivateTalkApp/MainTab/View/TabBarView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 // MARK: - Constants
 private struct Constants {
-    static let TAB_BAR_VIEW_SPACING = 0.0
+    static let TAB_BAR_VIEW_SPACING = 15.0
     static let ITEM_IN_TAB_SPACING = 5.0
     static let IMAGE_IN_TAB_WIDTH = 25.0
     static let IMAGE_IN_TAB_HEIGHT = 25.0
     static let TAB_HEIGHT = 30.0
-    static let TAB_VERTICAL = 10.0
+    static let TAB_BOTTOM = 8.0
 }
 
 // MARK: - TabBarView
@@ -47,33 +47,30 @@ private struct CustomTabBar: View {
     @Binding var currentTab: Tab
     
     var body: some View {
-        GeometryReader { geometry in
-            HStack(spacing: Constants.TAB_BAR_VIEW_SPACING) {
-                ForEach(Tab.allCases, id: \.hashValue) { tab in
-                    Button {
-                        // 選択されたタブをデフォルトのタブに設定する
-                        currentTab = tab
-                    } label: {
-                        VStack(spacing: Constants.ITEM_IN_TAB_SPACING) {
-                            Image(systemName: tab.imageName)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: Constants.IMAGE_IN_TAB_WIDTH, 
-                                       height: Constants.IMAGE_IN_TAB_HEIGHT)
-                                .foregroundStyle(currentTab == tab ? Color.foreground : .gray)
-                            Text(tab.tabText)
-                                .font(.caption)
-                                .foregroundStyle(Color.foreground)
-                        }
-                        .frame(maxWidth: .infinity)
+        HStack(spacing: Constants.TAB_BAR_VIEW_SPACING) {
+            ForEach(Tab.allCases, id: \.hashValue) { tab in
+                Button {
+                    // 選択されたタブをデフォルトのタブに設定する
+                    currentTab = tab
+                } label: {
+                    VStack(spacing: Constants.ITEM_IN_TAB_SPACING) {
+                        Image(systemName: tab.imageName)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: Constants.IMAGE_IN_TAB_WIDTH,
+                                   height: Constants.IMAGE_IN_TAB_HEIGHT)
+                            .foregroundStyle(currentTab == tab ? Color.foreground : .gray)
+                        Text(tab.tabText)
+                            .font(.caption)
+                            .foregroundStyle(Color.foreground)
                     }
-                    .disabled(currentTab == tab)
+                    .frame(maxWidth: .infinity)
                 }
+                .disabled(currentTab == tab)
             }
-            .frame(maxWidth: .infinity)
         }
         .frame(height: Constants.TAB_HEIGHT)
-        .padding(.vertical, Constants.TAB_VERTICAL)
+        .padding(.bottom, Constants.TAB_BOTTOM)
     }
 }
 

--- a/PrivateTalkApp/MainTab/View/TabBarView.swift
+++ b/PrivateTalkApp/MainTab/View/TabBarView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 // MARK: - Constants
 private struct Constants {
-    static let TAB_BAR_VIEW_SPACING = 15.0
+    static let TAB_BAR_VIEW_SPACING = 8.0
     static let ITEM_IN_TAB_SPACING = 5.0
     static let IMAGE_IN_TAB_WIDTH = 25.0
     static let IMAGE_IN_TAB_HEIGHT = 25.0
@@ -69,8 +69,6 @@ private struct CustomTabBar: View {
                 .disabled(currentTab == tab)
             }
         }
-        .frame(height: Constants.TAB_HEIGHT)
-        .padding(.bottom, Constants.TAB_BOTTOM)
     }
 }
 


### PR DESCRIPTION
# OverView
【**目的**】
- iPhone SEでTabのレイアウトが崩れていたので修正

| 修正前 | 修正後|
| ---- | ---- |
| <img width="200" alt="スクリーンショット 2024-09-21 21 11 51" src="https://github.com/user-attachments/assets/91039454-9e2e-4400-afd1-a9a65a2329ce"> | <img width="200" alt="スクリーンショット 2024-09-21 21 11 15" src="https://github.com/user-attachments/assets/b07690a8-3985-41c3-9a5c-17b3fc46f486">

【**実装内容**】
- Geometryreaderを使用していたところを削除
