### PR TITLE
@MainActorで警告が発生していたので修正

### DIFF
--- a/PrivateTalkApp/Home/View/CalendarView.swift
+++ b/PrivateTalkApp/Home/View/CalendarView.swift
@@ -87,7 +87,7 @@ final class FSCalendarCoordinator: NSObject, FSCalendarDelegate, FSCalendarDataS
     
     /// 年月を変更した際の処理
     /// - parameter calendar: FSCalendar
-    @MainActor func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
+    func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
         // コールバック呼び出し現在の年月を親Viewに渡す
         self.parent.onCurrentDateChanged(calendar.currentPage)
         self.parent.todayButtonEnable = false


### PR DESCRIPTION
# OverView
【**目的**】
- 以下の警告が出ていたので修正
`Main actor-isolated instance method 'calendarCurrentPageDidChange' cannot be used to satisfy nonisolated protocol requirement; this is an error in the Swift 6 language mode`

【**実装内容**】
- @MainActorが不要だったので削除