### PR TITLE
今日ボタンの活性非活性の制御ロジックを修正

### DIFF
--- a/PrivateTalkApp/Home/View/CalendarView.swift
+++ b/PrivateTalkApp/Home/View/CalendarView.swift
@@ -90,7 +90,17 @@ final class FSCalendarCoordinator: NSObject, FSCalendarDelegate, FSCalendarDataS
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
         // コールバック呼び出し現在の年月を親Viewに渡す
         self.parent.onCurrentDateChanged(calendar.currentPage)
-        self.parent.todayButtonEnable = false
+        Task { @MainActor in
+            if let today = calendar.today {
+                if self.parent.calendarViewModel.isMatchedDate(dateToCompare: today) {
+                    // カレンダーが今日の月だったら、今日ボタンを押せなくする
+                    self.parent.todayButtonEnable = true
+                } else {
+                    // カレンダーが今日の月でなければ、今日ボタンを押せるようにする
+                    self.parent.todayButtonEnable = false
+                }
+            }
+        }
     }
 }
 

--- a/PrivateTalkApp/Home/ViewModel/CalendarViewModel.swift
+++ b/PrivateTalkApp/Home/ViewModel/CalendarViewModel.swift
@@ -13,6 +13,7 @@ final class CalendarViewModel: ObservableObject {
     
     private struct Constants {
         static let FULL_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss"
+        static let YEAR_MONTH_DATE_FORMAT_KEY = "year_month_date_format"
     }
     
     // カレンダーのModel
@@ -53,15 +54,13 @@ final class CalendarViewModel: ObservableObject {
         }
     }
     
-    /// 日付がCalendarModelと一致しているかどうか
+    /// 年月がCalendarModelと一致しているかどうか
     /// - parameter dateToCompare: 比較したいDate
     /// - returns: 一致すればtrue / 一致しなければfalse
     func isMatchedDate(dateToCompare: Date) -> Bool {
-        // 比較したいDate
-        let timestampToCompare = DateUtilities.convertDateToTimestamp(date: dateToCompare)
-        // CalendarModelに保存しているDate
-        let displayDateTimestamp = DateUtilities.convertDateToTimestamp(date: self.calendarModel?.displayDate)
+        // 比較したい年月
+        let dateToCompareString = DateUtilities.convertDateToString(date: dateToCompare, format: Constants.YEAR_MONTH_DATE_FORMAT_KEY)
         
-        return displayDateTimestamp == timestampToCompare
+        return dateToCompareString == self.calendarModel?.displayYearMonthString
     }
 }


### PR DESCRIPTION
# OverView
【**目的**】
- 今日ボタンの活性非活性の制御で以下の不具合が見つかったので修正
手順: 今月から次月へ移動し、今月に戻る
事象: 今月を表示しているのに、今日ボタンを押下できてしまう

【**実装内容**】
- 月を変えるごとに、必ず今日ボタンを活性化するようにしていたが、表示している月が今月かどうか判断して、活性非活性を制御するように修正
- タイムスタンプで異なる日付を比べていたが、不要なため年月のみで比べるように修正